### PR TITLE
Develop

### DIFF
--- a/src/api/chatbot/agent/__init__.py
+++ b/src/api/chatbot/agent/__init__.py
@@ -57,6 +57,7 @@ def supervisor_node(state: State) -> Command[Literal["create_web_query", "create
     Returns:
         Command: A command indicating the next node to transition to.
     """
+    print("--- Supervisor Node ---")
     members = ["web_searcher", "diary_searcher", "url_fetcher"]
     system_prompt = (
         "You are a supervisor tasked with managing a conversation between the"
@@ -96,6 +97,7 @@ def remove_trailing_newline(text: str) -> str:
     return text.rstrip("\n")
 
 def chatbot_node(state: State) -> Command[Literal["__end__"]]:
+    print("--- Chatbot Node ---")
     llm = ChatGoogleGenerativeAI(model="gemini-1.5-pro", temperature=1.0)
     # llm = ChatAnthropic(model="claude-3-5-sonnet-latest")
     prompt = get_character_prompt(state["userid"])
@@ -108,7 +110,7 @@ def chatbot_node(state: State) -> Command[Literal["__end__"]]:
 
 
 def create_web_query_node(state: State) -> Command[Literal["web_searcher"]]:
-
+    print("--- Create Web Query Node ---")
     llm = ChatGoogleGenerativeAI(model="gemini-1.5-flash")
 
     # プロンプトはLangchain Hubから取得
@@ -124,12 +126,14 @@ def create_web_query_node(state: State) -> Command[Literal["web_searcher"]]:
     )
 
 def web_searcher_node(state: State) -> Command[Literal["chatbot"]]:
+    print("--- Web Searcher Node ---")
     return Command(
     goto="chatbot",
     update={"documents": google_search(state["query"])},
 )
 
 def create_diary_query_node(state: State) -> Command[Literal["diary_searcher"]]:
+    print("--- Create Diary Query Node ---")
     llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp")
 
     # プロンプトはLangchain Hubから取得
@@ -144,12 +148,14 @@ def create_diary_query_node(state: State) -> Command[Literal["diary_searcher"]]:
     )
 
 def diary_searcher_node(state: State) -> Command[Literal["chatbot"]]:
+    print("--- Diary Searcher Node ---")
     return Command(
     goto="chatbot",
     update={"documents": azure_ai_search(state["query"])},
 )
 
 def url_fetcher_node(state: State) -> Command[Literal["chatbot"]]:
+    print("--- URL Fetcher Node ---")
     return Command(
     goto="chatbot",
     update={"documents": []},

--- a/src/api/chatbot/agent/__init__.py
+++ b/src/api/chatbot/agent/__init__.py
@@ -110,7 +110,10 @@ def chatbot_node(state: State) -> Command[Literal["__end__"]]:
 def create_web_query_node(state: State) -> Command[Literal["web_searcher"]]:
 
     llm = ChatGoogleGenerativeAI(model="gemini-1.5-flash")
-    template = hub.pull("create_web_search_query")
+
+    # プロンプトはLangchain Hubから取得
+    # https://smith.langchain.com/hub/tomodo1773/create_web_search_query
+    template = hub.pull("tomodo1773/create_web_search_query")
     current_datetime = datetime.datetime.now(pytz.timezone("Asia/Tokyo")).strftime("%Y-%m-%d %H:%M:%S")
     prompt = template.partial(current_datetime=current_datetime)
     create_web_query_chain = prompt | llm | StrOutputParser()
@@ -128,7 +131,10 @@ def web_searcher_node(state: State) -> Command[Literal["chatbot"]]:
 
 def create_diary_query_node(state: State) -> Command[Literal["diary_searcher"]]:
     llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp")
-    template = hub.pull("create_diary_search_query")
+
+    # プロンプトはLangchain Hubから取得
+    # https://smith.langchain.com/hub/tomodo1773/create_diary_search_query
+    template = hub.pull("tomodo1773/create_diary_search_query")
     current_datetime = datetime.datetime.now(pytz.timezone("Asia/Tokyo")).strftime("%Y-%m-%d %H:%M:%S")
     prompt = template.partial(current_datetime=current_datetime)
     create_diary_query_chain = prompt | llm | StrOutputParser()

--- a/src/api/chatbot/agent/prompt.py
+++ b/src/api/chatbot/agent/prompt.py
@@ -20,7 +20,9 @@ def get_character_prompt(userid: str) -> str:
     user_profile = read_user_profile(userid)
     current_datetime = datetime.datetime.now(pytz.timezone("Asia/Tokyo")).strftime("%Y-%m-%d %H:%M:%S")
 
-    prompt = hub.pull("sister_edinet")
+    # プロンプトはLangchain Hubから取得
+    # https://smith.langchain.com/hub/tomodo1773/sister_edinet
+    prompt = hub.pull("tomodo1773/sister_edinet")
     character_prompt = prompt.partial(current_datetime=current_datetime,user_profile=user_profile)
 
     return character_prompt


### PR DESCRIPTION
This pull request introduces several debugging print statements and updates to the prompt templates used in various nodes of the chatbot agent. The most important changes include adding print statements for debugging purposes and updating the prompt templates to be fetched from Langchain Hub with specific identifiers.

Debugging improvements:

* Added print statements to indicate the entry into various nodes in the chatbot agent, such as `supervisor_node`, `chatbot_node`, `create_web_query_node`, `web_searcher_node`, `create_diary_query_node`, `diary_searcher_node`, and `url_fetcher_node`. [[1]](diffhunk://#diff-cf84b2b8fd736cbc52fa404f256863b214f4df7af636a216dcd4feee544a1f94R60) [[2]](diffhunk://#diff-cf84b2b8fd736cbc52fa404f256863b214f4df7af636a216dcd4feee544a1f94R100) [[3]](diffhunk://#diff-cf84b2b8fd736cbc52fa404f256863b214f4df7af636a216dcd4feee544a1f94L111-R118) [[4]](diffhunk://#diff-cf84b2b8fd736cbc52fa404f256863b214f4df7af636a216dcd4feee544a1f94R129-R141) [[5]](diffhunk://#diff-cf84b2b8fd736cbc52fa404f256863b214f4df7af636a216dcd4feee544a1f94R151-R158)

Prompt template updates:

* Updated the prompt template in `create_web_query_node` to be fetched from Langchain Hub using the identifier `tomodo1773/create_web_search_query`.
* Updated the prompt template in `create_diary_query_node` to be fetched from Langchain Hub using the identifier `tomodo1773/create_diary_search_query`.
* Updated the prompt template in `get_character_prompt` to be fetched from Langchain Hub using the identifier `tomodo1773/sister_edinet`.