### PR TITLE
不要なインポートを削除

### DIFF
--- a/src/api/chatbot/utils/transcript.py
+++ b/src/api/chatbot/utils/transcript.py
@@ -2,7 +2,6 @@ import getpass
 import os
 import tempfile
 
-from chatbot.agent.prompt import get_character_prompt
 from chatbot.database import NameCosmosDB
 from chatbot.utils import remove_trailing_newline
 from chatbot.utils.config import logger


### PR DESCRIPTION
This pull request includes a small change to the `src/api/chatbot/utils/transcript.py` file. The change removes an unused import statement for `get_character_prompt` from the `chatbot.agent.prompt` module.

* [`src/api/chatbot/utils/transcript.py`](diffhunk://#diff-821a196c5eebecdbb647a4f6a6258ab6c2644da4c540e8d1c6f2a80f5268b092L5): Removed unused import statement for `get_character_prompt` from `chatbot.agent.prompt`.