### PR TITLE
Fix error handling in audio messages

### DIFF
--- a/src/api/chatbot/main.py
+++ b/src/api/chatbot/main.py
@@ -210,7 +210,7 @@ async def handle_audio_async(event):
     except Exception as e:
         # メッセージを返信
         error_message = f"Error: {e}"
-        line_messennger.reply_message([error_message])
+        line_messennger.reply_message([TextMessage(text=error_message)])
         logger.error(f"Returned error message to the user: {e}")
 
 


### PR DESCRIPTION
## Summary
- handle exceptions for audio messages correctly by sending LINE TextMessage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6841478fb31083209091e178eef2eefb