### PR TITLE
fix: OpenAI依存関係の不足エラーを修正

### DIFF
--- a/src/mcp/function_app.py
+++ b/src/mcp/function_app.py
@@ -1,7 +1,9 @@
 import json
 import logging
+import os
 
 import azure.functions as func
+from openai import OpenAI
 from spotify_api import Client
 from spotipy import SpotifyException
 
@@ -357,9 +359,6 @@ perplexity_search_properties_json = json.dumps([prop.to_dict() for prop in perpl
 def perplexity_web_search(context) -> str:
     """MCP tool for web search using Perplexity API."""
     try:
-        import os
-        from openai import OpenAI
-
         content = json.loads(context)
         arguments = content.get("arguments", {})
         query = arguments.get("query", "")

--- a/src/mcp/pyproject.toml
+++ b/src/mcp/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "azure-identity>=1.16.0,<2",
     "spotipy>=2.23.0,<3",
     "python-dotenv>=1.0.0,<2",
+    "openai>=1.40.0,<2",
 ]
 
 [tool.uv]


### PR DESCRIPTION
Issue #102 を修正しました。

## 変更內容
- `src/mcp/pyproject.toml`に「openAI依存関係（openai>=1.40.0,<2）を追加
- `src/mcp/function_app.py`でOpenAIとosのインポートをファイル上部に移動
- 関数内の重複インポートを削除してPythonのベストプラクティスに準拠

Generated with [Claude Code](https://claude.ai/code)