### PR TITLE
feat: プレイリストに曲を追加するときにお気に入りにも自動追加する機能を実装

### DIFF
--- a/src/mcp/function_app.py
+++ b/src/mcp/function_app.py
@@ -313,11 +313,11 @@ def spotify_create_playlist(context) -> str:
     arg_name="context",
     type="mcpToolTrigger",
     toolName="spotify_add_tracks_to_playlist",
-    description="Add tracks to a specified playlist",
+    description="Add tracks to a specified playlist and automatically add to liked songs as well",
     toolProperties=add_tracks_to_playlist_properties_json,
 )
 def spotify_add_tracks_to_playlist(context) -> str:
-    """Handle adding tracks to a playlist."""
+    """Handle adding tracks to a playlist and automatically adding to liked songs."""
     try:
         content = json.loads(context)
         arguments = content.get("arguments", {})
@@ -326,9 +326,19 @@ def spotify_add_tracks_to_playlist(context) -> str:
         playlist_id = arguments.get("playlist_id")
         track_id = arguments.get("track_id")
         position = arguments.get("position")
+        
         # track_idをリストにして渡す（API互換のため）
-        result = spotify_client.add_tracks_to_playlist(playlist_id=playlist_id, track_ids=[track_id], position=position)
-        return f"トラック追加完了！: {result}"
+        playlist_result = spotify_client.add_tracks_to_playlist(playlist_id=playlist_id, track_ids=[track_id], position=position)
+        logger.info("Successfully added track to playlist")
+        
+        # プレイリスト追加後、お気に入りにも追加
+        try:
+            liked_result = spotify_client.add_track_to_liked_songs(track_id=track_id)
+            logger.info("Successfully added track to liked songs")
+            return f"トラック追加完了！プレイリストとお気に入りの両方に追加されました。Playlist: {playlist_result}, Liked: {liked_result}"
+        except Exception as e:
+            logger.error(f"Failed to add track to liked songs: {str(e)}")
+            return f"トラックはプレイリストに追加されましたが、お気に入りへの追加に失敗しました。Playlist: {playlist_result}, Error: {str(e)}"
 
     except SpotifyException as se:
         error_msg = f"Spotify Client error occurred: {str(se)}"


### PR DESCRIPTION
Issue #137の対応で、MCPサービスの`spotify_add_tracks_to_playlist`関数を修正しました。

## 変更内容
- プレイリストに曲を追加した後、自動的にお気に入りにも追加
- エラーハンドリングを改善
- 戻り値メッセージを日本語で両方の操作結果を報告

Generated with [Claude Code](https://claude.ai/code)