### PR TITLE
fix(api): OAuth関連メッセージが会話履歴に残らないようにする

### DIFF
--- a/src/api/chatbot/agent/__init__.py
+++ b/src/api/chatbot/agent/__init__.py
@@ -2,13 +2,13 @@
 
 from chatbot.agent.character_graph import ChatbotAgent
 from chatbot.agent.character_graph.nodes import (
-    OAUTH_COMPLETED_KEYWORD,
     diary_agent_node,
     ensure_drive_folder_node,
     ensure_google_settings_node,
     ensure_oauth_node,
     spotify_agent_node,
 )
+from chatbot.agent.services.google_settings import OAUTH_COMPLETED_KEYWORD
 
 __all__ = [
     "ChatbotAgent",

--- a/src/api/chatbot/agent/character_graph/graph.py
+++ b/src/api/chatbot/agent/character_graph/graph.py
@@ -10,7 +10,6 @@ from langgraph.graph import START, StateGraph
 from langgraph.types import Command
 
 from chatbot.agent.character_graph.nodes import (
-    OAUTH_COMPLETED_KEYWORD,
     chatbot_node,
     diary_agent_node,
     ensure_drive_folder_node,
@@ -21,6 +20,7 @@ from chatbot.agent.character_graph.nodes import (
     set_cached,
     spotify_agent_node,
 )
+from chatbot.agent.services.google_settings import OAUTH_COMPLETED_KEYWORD
 from chatbot.agent.character_graph.state import State
 from chatbot.utils.config import check_environment_variables, create_logger
 

--- a/src/api/chatbot/agent/character_graph/state.py
+++ b/src/api/chatbot/agent/character_graph/state.py
@@ -18,4 +18,3 @@ class State(TypedDict):
     userid: str
     profile: NotRequired[str]
     digest: NotRequired[str]
-    resume_value: NotRequired[str]  # aresumeで渡された値を保持

--- a/src/api/chatbot/main.py
+++ b/src/api/chatbot/main.py
@@ -173,10 +173,10 @@ async def google_drive_oauth_callback(
     フロー:
     1. OAuth認証情報を保存
     2. aresumeでOAUTH_COMPLETED_KEYWORDを渡す
-    3. ensure_oauth_nodeが再実行され、今度はcredentialsがあるのでensure_drive_folderへ遷移
+    3. ensure_oauth_nodeでresume値を確認し、OKならensure_drive_folderへgoto
     4. ensure_drive_folder_nodeでフォルダID入力をinterruptで要求
     """
-    from chatbot.agent.character_graph.nodes import OAUTH_COMPLETED_KEYWORD
+    from chatbot.agent.services.google_settings import OAUTH_COMPLETED_KEYWORD
 
     # state には userid を渡している前提
     userid = state
@@ -206,8 +206,8 @@ async def google_drive_oauth_callback(
 
         if interrupt_type == "missing_oauth":
             # OAuth要求のinterruptに対してaresumeを使用
-            # OAUTH_COMPLETED_KEYWORDを渡すことで、ensure_drive_folder_nodeで
-            # 即座にフォルダID入力のinterruptが発生する
+            # OAUTH_COMPLETED_KEYWORDを渡すことで、ensure_oauth_node内で
+            # resume値を確認し、ensure_drive_folderへgotoする
             logger.info("Resuming from missing_oauth interrupt with OAUTH_COMPLETED_KEYWORD")
             response = await agent.aresume(session_id, OAUTH_COMPLETED_KEYWORD)
         else:


### PR DESCRIPTION
## Summary
- OAuth未設定時にinterruptを使用して認証URLを返すように変更
- OAuthコールバック時にaresumeを使用して会話を再開するように変更
- フォルダID登録完了時の確認メッセージを削除

Closes #358

🤖 Generated with [Claude Code](https://claude.ai/code)