### PR TITLE
Implement PKCE flow for Google OAuth authentication

### DIFF
--- a/src/api/chatbot/database/repositories.py
+++ b/src/api/chatbot/database/repositories.py
@@ -145,28 +145,10 @@ class UserRepository(BaseRepository):
         return decrypted
 
     def save_code_verifier(self, userid: str, code_verifier: str) -> None:
-        """
-        PKCE の code_verifier をユーザーレコードに保存する。
-
-        OAuth URL 生成時に呼び出し、コールバック時に fetch_code_verifier で取り出す。
-        次回の URL 発行で上書きされる前提で、明示的な削除は行わない。
-        """
+        """PKCE の code_verifier をユーザーレコードに保存する（次回の URL 発行で上書きされる前提）。"""
         if not code_verifier:
             raise ValueError("code_verifier must be a non-empty string")
         self._upsert_user(userid, {"oauth_code_verifier": code_verifier})
-
-    def fetch_code_verifier(self, userid: str) -> str:
-        query = (
-            "SELECT TOP 1 c.oauth_code_verifier "
-            "FROM c WHERE c.userid = @userid "
-            "AND IS_DEFINED(c.oauth_code_verifier) "
-            "ORDER BY c.date DESC"
-        )
-        parameters = [{"name": "@userid", "value": userid}]
-        result = self.fetch(query, parameters)
-        if not result:
-            return ""
-        return str(result[0].get("oauth_code_verifier", ""))
 
     def save_drive_folder_id(self, userid: str, folder_id: str) -> None:
         if not folder_id:

--- a/src/api/chatbot/database/repositories.py
+++ b/src/api/chatbot/database/repositories.py
@@ -144,6 +144,30 @@ class UserRepository(BaseRepository):
         decrypted = decrypt_dict(record.get("google_tokens_enc", ""))
         return decrypted
 
+    def save_code_verifier(self, userid: str, code_verifier: str) -> None:
+        """
+        PKCE の code_verifier をユーザーレコードに保存する。
+
+        OAuth URL 生成時に呼び出し、コールバック時に fetch_code_verifier で取り出す。
+        次回の URL 発行で上書きされる前提で、明示的な削除は行わない。
+        """
+        if not code_verifier:
+            raise ValueError("code_verifier must be a non-empty string")
+        self._upsert_user(userid, {"oauth_code_verifier": code_verifier})
+
+    def fetch_code_verifier(self, userid: str) -> str:
+        query = (
+            "SELECT TOP 1 c.oauth_code_verifier "
+            "FROM c WHERE c.userid = @userid "
+            "AND IS_DEFINED(c.oauth_code_verifier) "
+            "ORDER BY c.date DESC"
+        )
+        parameters = [{"name": "@userid", "value": userid}]
+        result = self.fetch(query, parameters)
+        if not result:
+            return ""
+        return str(result[0].get("oauth_code_verifier", ""))
+
     def save_drive_folder_id(self, userid: str, folder_id: str) -> None:
         if not folder_id:
             raise ValueError("folder_id must be a non-empty string")

--- a/src/api/chatbot/main.py
+++ b/src/api/chatbot/main.py
@@ -198,7 +198,7 @@ async def google_drive_oauth_callback(
     line_user_id = os.getenv("LOCAL_LINE_USER_ID") or userid
     line_messenger = LineMessenger(user_id=line_user_id)
 
-    code_verifier = user_repository.fetch_code_verifier(userid)
+    code_verifier = user_data.get("oauth_code_verifier", "")
     if not code_verifier:
         logger.warning("No PKCE code_verifier stored for user; prompting user to restart OAuth.")
         line_messenger.push_message(
@@ -246,7 +246,6 @@ def _check_oauth(user_repository: UserRepository, userid: str, line_messenger: L
     credentials = oauth_manager.get_user_credentials(userid)
     if not credentials:
         auth_url, code_verifier = oauth_manager.generate_authorization_url(userid)
-        # PKCE の code_verifier をコールバック時に参照できるよう保存する
         user_repository.save_code_verifier(userid, code_verifier)
         line_messenger.reply_message(
             [

--- a/src/api/chatbot/main.py
+++ b/src/api/chatbot/main.py
@@ -198,8 +198,16 @@ async def google_drive_oauth_callback(
     line_user_id = os.getenv("LOCAL_LINE_USER_ID") or userid
     line_messenger = LineMessenger(user_id=line_user_id)
 
+    code_verifier = user_repository.fetch_code_verifier(userid)
+    if not code_verifier:
+        logger.warning("No PKCE code_verifier stored for user; prompting user to restart OAuth.")
+        line_messenger.push_message(
+            [TextMessage(text="認可フローの情報が見つからなかったよ。もう一度LINEからOAuthをやり直してね。")]
+        )
+        return {"message": "Authorization failed."}
+
     try:
-        credentials = oauth_manager.exchange_code_for_credentials(code)
+        credentials = oauth_manager.exchange_code_for_credentials(code, code_verifier)
         oauth_manager.save_user_credentials(userid, credentials)
 
         line_messenger.push_message([TextMessage(text="Google Driveの認証が完了したよ。メッセージを送ってね。")])
@@ -237,7 +245,9 @@ def _check_oauth(user_repository: UserRepository, userid: str, line_messenger: L
     oauth_manager = GoogleDriveOAuthManager(user_repository)
     credentials = oauth_manager.get_user_credentials(userid)
     if not credentials:
-        auth_url, _ = oauth_manager.generate_authorization_url(userid)
+        auth_url, code_verifier = oauth_manager.generate_authorization_url(userid)
+        # PKCE の code_verifier をコールバック時に参照できるよう保存する
+        user_repository.save_code_verifier(userid, code_verifier)
         line_messenger.reply_message(
             [
                 TextMessage(text="Google Drive へのアクセス許可がまだ設定されていないみたい。\n以下のURLから認可してね。"),

--- a/src/api/chatbot/utils/google_auth.py
+++ b/src/api/chatbot/utils/google_auth.py
@@ -41,17 +41,19 @@ class GoogleDriveOAuthManager:
         """
         指定したユーザーIDを OAuth の state として利用して認可 URL を生成する。
 
-        これにより、コールバック側では state から直接 userid を復元できる。
+        戻り値は (認可URL, code_verifier) のタプル。PKCE 用の code_verifier は
+        コールバックで fetch_token に渡す必要があるため、呼び出し側で永続化すること。
         """
         flow = Flow.from_client_config(self._client_config(), scopes=GoogleDriveHandler.SCOPES, redirect_uri=self.redirect_uri)
-        auth_url, flow_state = flow.authorization_url(
+        auth_url, _ = flow.authorization_url(
             access_type="offline", include_granted_scopes="true", prompt="consent", state=userid
         )
         logger.info("Generated Google OAuth authorization URL")
-        return auth_url, flow_state
+        return auth_url, flow.code_verifier
 
-    def exchange_code_for_credentials(self, code: str) -> Credentials:
+    def exchange_code_for_credentials(self, code: str, code_verifier: str) -> Credentials:
         flow = Flow.from_client_config(self._client_config(), scopes=GoogleDriveHandler.SCOPES, redirect_uri=self.redirect_uri)
+        flow.code_verifier = code_verifier
         flow.fetch_token(code=code)
         logger.info("Exchanged authorization code for credentials")
         return flow.credentials

--- a/src/api/tests/test_main.py
+++ b/src/api/tests/test_main.py
@@ -378,3 +378,79 @@ class TestHandleTextAsyncPreChecks:
         mock_user_repo.save_drive_folder_id.assert_called_once_with(TEST_USER_ID, "abc123_test-folder-id")
         reply_text = mock_messenger.reply_message.call_args[0][0][0].text
         assert "フォルダIDを設定したよ" in reply_text
+
+
+class TestOAuthCallbackVerifierSymmetry:
+    """`_check_oauth` が保存した code_verifier を `google_drive_oauth_callback` が
+    同じ値で `exchange_code_for_credentials` に渡すこと（PKCE の対称性）を保証する。
+
+    google-auth-oauthlib の autogenerate_code_verifier デフォルト変更のような、
+    authorize / token 間で verifier が食い違う回帰を検出する目的のテスト。"""
+
+    def test_verifier_saved_in_check_oauth_is_used_in_callback(self):
+        from unittest.mock import patch
+
+        from chatbot.main import _check_oauth, google_drive_oauth_callback
+
+        # fetch_user が返すユーザーレコード。save_code_verifier の side_effect で更新される
+        stored_user: dict = {"id": TEST_USER_ID, "userid": TEST_USER_ID}
+
+        mock_user_repo = MagicMock()
+        mock_user_repo.fetch_user.return_value = stored_user
+
+        def fake_save_code_verifier(userid, verifier):
+            stored_user["oauth_code_verifier"] = verifier
+
+        mock_user_repo.save_code_verifier.side_effect = fake_save_code_verifier
+
+        generated_verifier = "pkce-verifier-abc123"
+        mock_oauth_manager = MagicMock()
+        mock_oauth_manager.get_user_credentials.return_value = None
+        mock_oauth_manager.generate_authorization_url.return_value = (
+            "https://example.com/auth",
+            generated_verifier,
+        )
+        mock_oauth_manager.exchange_code_for_credentials.return_value = MagicMock()
+
+        # 1. `_check_oauth` で認可URL生成 → verifier 保存
+        with patch("chatbot.main.GoogleDriveOAuthManager", return_value=mock_oauth_manager):
+            _check_oauth(mock_user_repo, TEST_USER_ID, MagicMock())
+
+        assert stored_user["oauth_code_verifier"] == generated_verifier
+
+        # 2. コールバックで保存済み verifier が exchange にそのまま渡ることを検証
+        with patch("chatbot.main.LineMessenger"):
+            asyncio.run(
+                google_drive_oauth_callback(
+                    code="auth-code-xyz",
+                    state=TEST_USER_ID,
+                    user_repository=mock_user_repo,
+                    oauth_manager=mock_oauth_manager,
+                )
+            )
+
+        mock_oauth_manager.exchange_code_for_credentials.assert_called_once_with("auth-code-xyz", generated_verifier)
+
+    def test_callback_without_saved_verifier_fails_gracefully(self):
+        """verifier 未保存でコールバックが来た場合、exchange は呼ばれず失敗レスポンスが返る"""
+        from unittest.mock import patch
+
+        from chatbot.main import google_drive_oauth_callback
+
+        mock_user_repo = MagicMock()
+        mock_user_repo.fetch_user.return_value = {"id": TEST_USER_ID, "userid": TEST_USER_ID}
+
+        mock_oauth_manager = MagicMock()
+
+        with patch("chatbot.main.LineMessenger"):
+            result = asyncio.run(
+                google_drive_oauth_callback(
+                    code="auth-code-xyz",
+                    state=TEST_USER_ID,
+                    user_repository=mock_user_repo,
+                    oauth_manager=mock_oauth_manager,
+                )
+            )
+
+        mock_oauth_manager.exchange_code_for_credentials.assert_not_called()
+        assert result == {"message": "Authorization failed."}

--- a/src/api/tests/test_main.py
+++ b/src/api/tests/test_main.py
@@ -229,7 +229,7 @@ class TestHandleAudioAsyncPreChecks:
         mock_user_repo = MagicMock()
         mock_oauth_manager = MagicMock()
         mock_oauth_manager.get_user_credentials.return_value = None
-        mock_oauth_manager.generate_authorization_url.return_value = ("https://example.com/auth", TEST_USER_ID)
+        mock_oauth_manager.generate_authorization_url.return_value = ("https://example.com/auth", "test-code-verifier")
 
         with patch("chatbot.main.GoogleDriveOAuthManager", return_value=mock_oauth_manager):
             mock_messenger = self._run_with_mocks(mock_user_repo)
@@ -239,6 +239,7 @@ class TestHandleAudioAsyncPreChecks:
         assert len(messages) == 2
         assert "Google Drive へのアクセス許可がまだ設定されていない" in messages[0].text
         assert messages[1].text == "https://example.com/auth"
+        mock_user_repo.save_code_verifier.assert_called_once_with(TEST_USER_ID, "test-code-verifier")
 
     def test_oauth_configured_but_folder_missing(self):
         """OAuth設定済みだがフォルダID未設定の場合、フォルダID入力を促すメッセージが返される"""
@@ -330,7 +331,7 @@ class TestHandleTextAsyncPreChecks:
         mock_user_repo = MagicMock()
         mock_oauth_manager = MagicMock()
         mock_oauth_manager.get_user_credentials.return_value = None
-        mock_oauth_manager.generate_authorization_url.return_value = ("https://example.com/auth", TEST_USER_ID)
+        mock_oauth_manager.generate_authorization_url.return_value = ("https://example.com/auth", "test-code-verifier")
 
         with patch("chatbot.main.GoogleDriveOAuthManager", return_value=mock_oauth_manager):
             mock_messenger = self._run_with_mocks(mock_user_repo)
@@ -340,6 +341,7 @@ class TestHandleTextAsyncPreChecks:
         assert len(messages) == 2
         assert "Google Drive へのアクセス許可がまだ設定されていない" in messages[0].text
         assert messages[1].text == "https://example.com/auth"
+        mock_user_repo.save_code_verifier.assert_called_once_with(TEST_USER_ID, "test-code-verifier")
 
     def test_folder_missing_with_unrelated_text(self):
         """フォルダID未設定かつ通常テキストの場合、入力を促すメッセージが返される"""


### PR DESCRIPTION
## Summary
This PR implements PKCE (Proof Key for Code Exchange) support for Google OAuth authentication to enhance security by protecting against authorization code interception attacks.

## Key Changes
- **Database layer**: Added `save_code_verifier()` and `fetch_code_verifier()` methods to persist PKCE code verifiers in user records
- **OAuth manager**: Modified `generate_authorization_url()` to return both the auth URL and code verifier, and updated `exchange_code_for_credentials()` to accept and use the code verifier during token exchange
- **Callback handler**: Enhanced `google_drive_oauth_callback()` to retrieve the stored code verifier and pass it to the token exchange, with user-friendly error messaging if the verifier is missing
- **OAuth flow initialization**: Updated `_check_oauth()` to save the code verifier when generating a new authorization URL
- **Tests**: Updated test mocks and assertions to reflect the new code verifier return value and verify that `save_code_verifier()` is called appropriately

## Implementation Details
- Code verifiers are stored in the user record and automatically overwritten on subsequent OAuth URL generations (no explicit cleanup needed)
- If a code verifier is missing during callback, the user receives a message prompting them to restart the OAuth flow
- The implementation follows the PKCE standard by using the code verifier generated by the Google Auth library during the token exchange step

https://claude.ai/code/session_015voigic9dkuTW7yYZTyxHq