### PR TITLE
fix(infra): pin uv behavior on API App Service to avoid deploy-time r…

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -126,6 +126,8 @@ module AppService './app/api.bicep' = {
       POSTGRES_CHECKPOINT_URL: '@Microsoft.KeyVault(SecretUri=${keyVault.properties.vaultUri}secrets/POSTGRES-CHECKPOINT-URL)'
       COSMOS_DB_CONNECTION_VERIFY: 'true'
       APPLICATIONINSIGHTS_CONNECTION_STRING: monitoring.outputs.applicationInsightsConnectionString
+      UV_FROZEN: 'true'
+      UV_NO_DEV: 'true'
     }
   }
 }


### PR DESCRIPTION
…e-resolve

Oryx の uv sync はデフォルトで --frozen/--no-dev を付けずに呼ばれるため、 exclude-newer = "7 days" の値が毎回ズレて uv.lock が再解決され、dev 依存の pytest まで取得してディスクを食い潰しデプロイが失敗していた。

App Service 側で UV_FROZEN/UV_NO_DEV を設定し、ロック通りに本番依存のみ インストールさせる。

Refs: https://docs.astral.sh/uv/reference/environment/