### PR TITLE
feat(api): containerize API for Cloud Run migration

### DIFF
--- a/src/api/.dockerignore
+++ b/src/api/.dockerignore
@@ -1,0 +1,11 @@
+.venv
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+tests
+images
+README.md
+.env
+.env.*

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim-bookworm
+
+COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /uvx /bin/
+
+WORKDIR /app
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH"
+
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev --no-install-project
+
+COPY chatbot ./chatbot
+
+CMD ["sh", "-c", "exec fastapi run --entrypoint chatbot.main:app --host 0.0.0.0 --port ${PORT:-8080} --proxy-headers"]


### PR DESCRIPTION
## Summary
- API サービスを Cloud Run に移行するため Dockerfile と .dockerignore を追加
- uv 公式イメージから bin をコピーしてビルド。`uv sync --locked --no-dev` で再現性担保
- Cloud Run の PORT 環境変数に追従する `CMD ["sh", "-c", "exec fastapi run ..."]` 形式

## Background
App Service F1 の /home 1GB クォータで依存（langchain / google-api-* 等）が入り切らずデプロイ失敗が継続。Container Apps は有料、Cloud Run は無料枠内で動かせるため API だけ移行する。

## Test plan
- [x] ローカルで `docker build` 成功（イメージ 740MB）
- [x] ローカルで起動確認（env 不足で期待通り落ちる、import は通る）
- [ ] main merge 後、Cloud Build トリガー発火 → イメージ build 成功
- [ ] Cloud Run サービスに env vars 設定後、LINE webhook 応答確認