### PR TITLE
fix(api): drop BuildKit cache mount for Cloud Build compatibility

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -10,8 +10,7 @@ ENV UV_COMPILE_BYTECODE=1 \
     PATH="/app/.venv/bin:$PATH"
 
 COPY pyproject.toml uv.lock ./
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev --no-install-project
+RUN uv sync --locked --no-dev --no-install-project
 
 COPY chatbot ./chatbot
 


### PR DESCRIPTION
Cloud Build のデフォルト Docker ビルダーは BuildKit 無効で `--mount=type=cache` が使えずビルドが失敗していたため削除。