### PR TITLE
fix(api): use uv sync --frozen to avoid exclude-newer drift

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -10,7 +10,7 @@ ENV UV_COMPILE_BYTECODE=1 \
     PATH="/app/.venv/bin:$PATH"
 
 COPY pyproject.toml uv.lock ./
-RUN uv sync --locked --no-dev --no-install-project
+RUN uv sync --frozen --no-dev --no-install-project
 
 COPY chatbot ./chatbot
 


### PR DESCRIPTION
## Summary
- Cloud Run のデプロイが `uv sync --locked` で失敗していた問題を修正
- `pyproject.toml` の `[tool.uv] exclude-newer = \"7 days\"` が相対指定のため、ビルドのたびにカットオフ日が動き、ロックファイルが「更新が必要」と判定されていた
- `--locked`（lockfile と再解決結果の一致を要求）から `--frozen`（再解決自体をスキップして lockfile をそのまま使う）に変更し、`exclude-newer` の影響を受けないようにした

## Test plan
- [ ] Cloud Build がビルド成功すること
- [ ] Cloud Run の起動と /health 応答を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)