### PR TITLE
chore(infra): set UV_CACHE_DIR to /tmp on AppService

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -126,6 +126,7 @@ module AppService './app/api.bicep' = {
       COSMOS_DB_CONNECTION_VERIFY: 'true'
       UV_FROZEN: 'true'
       UV_NO_DEV: 'true'
+      UV_CACHE_DIR: '/tmp/uv-cache'
     }
   }
 }


### PR DESCRIPTION
## Summary
- App Service Free プランの \`/home\` (1GB) に uv キャッシュが累積しデプロイが No space left on device で失敗する事象への恒久対策
- AppService の appSettings に \`UV_CACHE_DIR=/tmp/uv-cache\` を追加し、ビルド時のキャッシュを ephemeral な \`/tmp\` に逃がす

## Background
4/15 のデプロイ失敗の根本原因はライブラリ追加ではなく、デプロイのたびに \`/home/.cache/uv\` が肥大化していたこと（実測 767MB / pip と合わせて 929MB）。永続ディスクを汚さないようにする。

## Test plan
- [ ] \`/home/.cache/uv\` を一度クリアした上で本変更をデプロイし、ビルドが \`/tmp/uv-cache\` を使うことを確認
- [ ] 再デプロイを数回繰り返しても \`/home\` の空きが減らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)