### PR TITLE
使用モデルをGPT-5.6ファミリーに更新

### DIFF
--- a/src/api/chatbot/agent/character_graph/graph.py
+++ b/src/api/chatbot/agent/character_graph/graph.py
@@ -65,7 +65,7 @@ class ChatbotAgent:
 
         system_prompt = DEEP_AGENT_PROMPT.format(current_datetime=get_japan_datetime())
 
-        llm = ChatOpenAI(model="gpt-5.2", temperature=1.0)
+        llm = ChatOpenAI(model="gpt-5.6-terra", reasoning_effort="low")
         agent = create_deep_agent(
             model=llm,
             tools=all_tools,

--- a/src/api/chatbot/utils/diary_utils.py
+++ b/src/api/chatbot/utils/diary_utils.py
@@ -139,7 +139,7 @@ def generate_diary_digest(diary_content: str) -> str:
             ]
         )
 
-        llm = ChatOpenAI(model="gpt-5.2", temperature=0.2)
+        llm = ChatOpenAI(model="gpt-5.6-luna", reasoning_effort="none")
         chain = template | llm | StrOutputParser()
 
         return chain.invoke({"diary_content": diary_content})

--- a/src/api/chatbot/utils/transcript.py
+++ b/src/api/chatbot/utils/transcript.py
@@ -70,7 +70,7 @@ class DiaryTranscription:
             raise RuntimeError(f"Generate diary transcription error: {e}") from e
 
     def _create_chain(self):
-        chat = ChatOpenAI(model="gpt-4o", temperature=0.2)
+        chat = ChatOpenAI(model="gpt-5.6-luna", reasoning_effort="none")
         # chat = ChatGoogleGenerativeAI(
         #     model="gemini-1.5-pro-latest",
         #     temperature=0.2,

--- a/src/func/digest_reorganizer.py
+++ b/src/func/digest_reorganizer.py
@@ -152,7 +152,9 @@ class DeepAgentFactory:
 class DigestReorganizer:
     """digest.json の再編処理を Deep Agent で実行する。"""
 
-    def __init__(self, *, agent_factory: Callable[[Path], AgentRunner] | None = None, model_name: str = "gpt-5.6-terra") -> None:
+    def __init__(
+        self, *, agent_factory: Callable[[Path], AgentRunner] | None = None, model_name: str = "gpt-5.6-terra"
+    ) -> None:
         self.agent_factory = agent_factory or DeepAgentFactory(model_name)
 
     def reorganize(self, raw_digest: str, *, today_override: str | None = None) -> str:

--- a/src/func/digest_reorganizer.py
+++ b/src/func/digest_reorganizer.py
@@ -141,18 +141,18 @@ def _update_last_updated(content: str, today: str) -> str:
 
 @dataclass
 class DeepAgentFactory:
-    model_name: str = "gpt-5.2"
+    model_name: str = "gpt-5.6-terra"
 
     def __call__(self, workspace: Path) -> AgentRunner:
         backend = FilesystemBackend(root_dir=workspace, virtual_mode=True)
-        llm = ChatOpenAI(model=self.model_name, temperature=0, reasoning_effort="medium")
+        llm = ChatOpenAI(model=self.model_name, reasoning_effort="medium")
         return create_deep_agent(model=llm, system_prompt=SYSTEM_PROMPT, backend=backend)
 
 
 class DigestReorganizer:
     """digest.json の再編処理を Deep Agent で実行する。"""
 
-    def __init__(self, *, agent_factory: Callable[[Path], AgentRunner] | None = None, model_name: str = "gpt-5.2") -> None:
+    def __init__(self, *, agent_factory: Callable[[Path], AgentRunner] | None = None, model_name: str = "gpt-5.6-terra") -> None:
         self.agent_factory = agent_factory or DeepAgentFactory(model_name)
 
     def reorganize(self, raw_digest: str, *, today_override: str | None = None) -> str:


### PR DESCRIPTION
## 概要

2026年7月リリースのGPT-5.6ファミリー（Sol/Terra/Luna）への移行。処理内容に応じてティアとreasoning_effortを使い分ける。

## 変更内容

| 用途 | 変更前 | 変更後 |
|---|---|---|
| キャラクター会話 (graph.py) | gpt-5.2 (temperature=1.0) | gpt-5.6-terra (reasoning_effort=low) |
| 日記ダイジェスト生成 (diary_utils.py) | gpt-5.2 (temperature=0.2) | gpt-5.6-luna (reasoning_effort=none) |
| digest再編成 (digest_reorganizer.py) | gpt-5.2 (temperature=0, medium) | gpt-5.6-terra (reasoning_effort=medium) |
| 文字起こし整形 (transcript.py) | gpt-4o (temperature=0.2) | gpt-5.6-luna (reasoning_effort=none) |

## 選定理由

- **会話**: LINE応答のレイテンシ重視でTerra + low。品質はGPT-5.5級でコストは半分
- **ダイジェスト生成/文字起こし整形**: 軽量な整形・抽出タスクなのでLuna + noneで十分
- **digest再編成**: バッチ処理で正確性重視のためTerra + mediumを維持
- reasoning系モデルではtemperature指定がエラーになりうるため、temperatureは撤去してreasoning_effortで制御

gpt-4o-transcribe（音声文字起こし）はバッチSTTの後継が未リリースのため現状維持。

## テスト

- API側: 31 passed
- Functions側: 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)